### PR TITLE
Add header guards and includes to spr_parser

### DIFF
--- a/spr_parser.h
+++ b/spr_parser.h
@@ -1,5 +1,15 @@
+#ifndef SPR_PARSER_H
+#define SPR_PARSER_H
+
 #include <filesystem> // C++17, but widely used with C++20
 #include <string>
+#include <fstream>
+#include <sstream>
+#include <map>
+#include <vector>
+#include <memory>
+#include <iostream>
+#include <cctype>
 #include "image_item.h"
 
 namespace fs = std::filesystem;
@@ -283,3 +293,4 @@ std::shared_ptr<ImageItem> load_spr_file(const std::string& filename, const fs::
 
     return item;
 }
+#endif // SPR_PARSER_H


### PR DESCRIPTION
## Summary
- wrap `spr_parser.h` with `SPR_PARSER_H` include guard
- add missing standard library includes

## Testing
- `make build` *(fails: gtkmm-3.0 and cairomm-1.0 missing)*
- `make test` *(fails: gtkmm-3.0 and cairomm-1.0 missing, test.cpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854ce5446e0832fa389c69553934b12