### PR TITLE
Fix image_item header guard

### DIFF
--- a/image_item.h
+++ b/image_item.h
@@ -1,5 +1,10 @@
 #ifndef IMAGE_ITEM_H
-#pragma once
+#define IMAGE_ITEM_H
+
+#include <vector>
+#include <iostream>
+#include <glibmm/refptr.h>
+#include <gdkmm/pixbuf.h>
 #include <filesystem> // C++17, but widely used with C++20
 namespace fs = std::filesystem;
 
@@ -64,4 +69,4 @@ struct ImageItem {
         std::cout << "----------------------" << std::endl;
     }
 };
-#endif //IMAGE_ITEM_H
+#endif // IMAGE_ITEM_H


### PR DESCRIPTION
## Summary
- ensure `image_item.h` uses a proper header guard
- include standard headers for vector, iostream and gtkmm types

## Testing
- `make test` *(fails: Package gtkmm-3.0 not found, test.cpp missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854ce5184d8832fac012c38ef37fe12