### PR TITLE
Document asset path and use relative default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # Vegastrike Sprite Editor
 Written in C++ using gtkmm-3.0.
 Compile with make.
+
+## Asset configuration
+The editor looks for a file called `vs_anim.cfg` in the working directory. This
+file should contain the path to the root of your sprite assets. You may supply
+an absolute path or a path relative to the program's start directory. The
+repository includes `vs_anim.cfg` with a sample relative path:
+
+```
+assets
+```
+
+Edit `vs_anim.cfg` to point to your own sprite directory before running the
+application.

--- a/vs_anim.cfg
+++ b/vs_anim.cfg
@@ -1,1 +1,1 @@
-/home/james/Project/WCUniverse/sprites
+assets


### PR DESCRIPTION
## Summary
- change `vs_anim.cfg` to a relative path `assets`
- clarify in README how to change `vs_anim.cfg`

## Testing
- `make build` *(fails: gtkmm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854ce5d1008832f840e48ce9fc3f23c