### PR TITLE
Add basic C++ unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 build:
 	g++ -std=c++20 vegastrike_animation.cpp -o vs_spredit `pkg-config gtkmm-3.0 cairomm-1.0 --cflags --libs`
-test:
+
+test: test.cpp
 	g++ -std=c++20 test.cpp -o test `pkg-config gtkmm-3.0 cairomm-1.0 --cflags --libs`
+	./test
+
 clean:
-	rm vs_spredit
+	rm -f vs_spredit test

--- a/image_item.h
+++ b/image_item.h
@@ -1,6 +1,10 @@
 #ifndef IMAGE_ITEM_H
 #pragma once
 #include <filesystem> // C++17, but widely used with C++20
+#include <gtkmm.h>
+#include <vector>
+#include <memory>
+#include <iostream>
 namespace fs = std::filesystem;
 
 struct ImageItem {

--- a/spr_parser.h
+++ b/spr_parser.h
@@ -1,5 +1,11 @@
 #include <filesystem> // C++17, but widely used with C++20
 #include <string>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <vector>
+#include <map>
+#include <memory>
 #include "image_item.h"
 
 namespace fs = std::filesystem;

--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,36 @@
+#include "spr_parser.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    // ends_with
+    assert(ends_with("file.ani", ".ani"));
+    assert(!ends_with("file.spr", ".ani"));
+
+    // is_integer
+    assert(is_integer("123"));
+    assert(is_integer("-45"));
+    assert(!is_integer("12a"));
+    assert(!is_integer("+"));
+
+    // is_double
+    assert(is_double("12.3"));
+    assert(is_double("-0.5"));
+    assert(is_double("3"));
+    assert(!is_double("abc"));
+
+    // parse_cropping_params
+    double mins=0, mint=0, maxs=0, maxt=0;
+    bool ok = parse_cropping_params("mins=0.1,mint=0.2,maxs=0.8,maxt=0.9", mins, mint, maxs, maxt);
+    assert(ok);
+    assert(mins == 0.1);
+    assert(mint == 0.2);
+    assert(maxs == 0.8);
+    assert(maxt == 0.9);
+
+    ok = parse_cropping_params("mins=0.1,mint=foo,maxs=1,maxt=0.9", mins, mint, maxs, maxt);
+    assert(!ok);
+
+    std::cout << "All tests passed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a simple test suite covering helper functions
- update Makefile to build and run tests
- include missing headers in `image_item.h` and `spr_parser.h`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6854d21268a8832f8f611aa6f9ded6e4